### PR TITLE
Add DataMigration API

### DIFF
--- a/oopgrade/__init__.py
+++ b/oopgrade/__init__.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import
+
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution(__name__).version
 except Exception, e:
     VERSION = 'unknown'
+
+from oopgrade.data import DataMigration

--- a/oopgrade/data.py
+++ b/oopgrade/data.py
@@ -24,9 +24,6 @@ class DataMigration(object):
             search_params = {}
         self.search_params = search_params.copy()
         self.records = []
-        obj = objectify.fromstring(self.content)
-        for record in obj.iter(tag='record'):
-            self.records.append(self._record(record))
 
     def _record(self, record):
         vals = {}
@@ -75,9 +72,11 @@ class DataMigration(object):
         return self.cursor.fetchone()[0]
 
     def migrate(self):
+        obj = objectify.fromstring(self.content)
         t = Table('ir_model_data')
-        for record in self.records:
-            res_id = None
+        for xml_record in obj.iter(tag='record'):
+            record = self._record(xml_record)
+            self.records.append(record)
             sp = []
             for field in self.search_params.get(record.model, record.vals.keys()):
                 sp.append((field, '=', record.vals[field]))

--- a/oopgrade/data.py
+++ b/oopgrade/data.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+from __future__ import absolute_import
+
+from collections import namedtuple
+from ast import literal_eval
+
+from lxml import objectify
+from oopgrade.oopgrade import get_foreign_keys, logger
+from ooquery import OOQuery
+from sql import Table
+
+
+DataRecord = namedtuple('DataRecord', ['id', 'model', 'noupdate', 'vals'])
+
+
+class DataMigration(object):
+    """Data Migration class
+    """
+    def __init__(self, content, cursor, module, search_params=None):
+        self.content = content
+        self.cursor = cursor
+        self.module = module
+        if search_params is None:
+            search_params = {}
+        self.search_params = search_params.copy()
+        self.records = []
+        obj = objectify.fromstring(self.content)
+        for record in obj.iter(tag='record'):
+            self.records.append(self._record(record))
+
+    def _record(self, record):
+        vals = {}
+        noupdate = int(record.getparent().attrib.get('noupdate', '0'))
+        for field in record.iter(tag='field'):
+            key = field.attrib['name']
+            attrs = field.attrib
+            if attrs.get('eval'):
+                value = literal_eval(attrs['eval'])
+            elif attrs.get('ref'):
+                value = self._ref(attrs['ref'])
+            elif attrs.get('search') and attrs.get('model'):
+                value = self._search(attrs['model'], attrs['search'])
+            else:
+                value = field.text
+            vals[key] = value
+        return DataRecord(
+            record.attrib['id'], record.attrib['model'], noupdate, vals
+        )
+
+    def _ref(self, ref):
+        if '.' in ref:
+            module, xml_id = ref.split('.')
+        else:
+            xml_id = ref
+            module = self.module
+
+        t = Table('ir_model_data')
+        select = t.select(t.res_id)
+        select.where = (t.module == module) & (t.name == xml_id)
+
+        self.cursor.execute(*select)
+        res = self.cursor.fetchone()
+        if not res:
+            raise KeyError('Reference: {}.{} not found'.format(
+                module, xml_id
+            ))
+        return res[0]
+
+    def _search(self, model, search):
+        table = model.replace('.', '_')
+        search_params = literal_eval(search)
+        q = OOQuery(table, lambda t: get_foreign_keys(self.cursor, t))
+        sql = q.select(['id']).where(search_params)
+        self.cursor.execute(*sql)
+        return self.cursor.fetchone()[0]
+
+    def migrate(self):
+        t = Table('ir_model_data')
+        for record in self.records:
+            res_id = None
+            sp = []
+            for field in self.search_params.get(record.model, record.vals.keys()):
+                sp.append((field, '=', record.vals[field]))
+            logger.info('Trying to find existing record with query: {}'.format(
+                sp
+            ))
+            table = record.model.replace('.', '_')
+            q = OOQuery(table)
+            sql = q.select(['id']).where(sp)
+            logger.debug(tuple(sql))
+            self.cursor.execute(*sql)
+            res_id = self.cursor.fetchone()
+            if res_id:
+                res_id = res_id[0]
+                logger.info('Record {}.{} found! ({} id:{})'.format(
+                    self.module, record.id, record.model, res_id
+                ))
+            else:
+                logger.info('Record {}.{} not found!'.format(
+                    self.module, record.id
+                ))
+                # We have to create the model
+                table_model = Table(record.model.replace('.', '_'))
+                columns = []
+                values = []
+                for col, value in record.vals.items():
+                    columns.append(getattr(table_model, col))
+                    values.append(value)
+
+                sql = table_model.insert(
+                    columns=columns, values=[values], returning=[table_model.id]
+                )
+                logger.debug(tuple(sql))
+                self.cursor.execute(*sql)
+                res_id = self.cursor.fetchone()[0]
+                logger.info('Creating record {}.{} ({} id:{})'.format(
+                    self.module, record.id, record.model, res_id
+                ))
+
+            sql = t.insert(
+                columns=[t.name, t.model, t.noupdate, t.res_id, t.module],
+                values=[(record.id, record.model, record.noupdate, res_id,
+                         self.module)]
+            )
+            logger.debug(tuple(sql))
+            logger.info('Linking model data {}.{} -> record {} id:{}'.format(
+                self.module, record.id, record.model, res_id
+            ))
+            self.cursor.execute(*sql)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 mamba
 expects
+mock

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     url='https://github.com/gisce/oopgrade',
     packages=find_packages(),
     install_requires=[
-        'semver'
+        'ooquery',
+        'semver',
+        'lxml',
+        'python-sql'
     ],
     license='AGPL-3',
 )

--- a/spec/data_migration_spec.py
+++ b/spec/data_migration_spec.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+from spec.fixtures import get_fixture
+from expects import *
+from mock import Mock, call
+
+from oopgrade import DataMigration
+from oopgrade.data import DataRecord
+
+
+
+with description('Migrating _data.xml'):
+    with before.all:
+        with open(get_fixture('migration_data.xml'), 'r') as f:
+            self.xml = f.read()
+
+    with it('must parse xml files with records'):
+        cursor = Mock()
+        cursor.fetchone.return_value = [435]
+        dm = DataMigration(self.xml, cursor, 'module')
+        expect(dm.records).to(have_len(3))
+
+    with context('a DataRecord class'):
+        with before.all:
+            cursor = Mock()
+            cursor.fetchone.return_value = [435]
+            self.r = DataRecord('id', 'model', 'noupdate', 'vals')
+            self.dm = DataMigration(self.xml, cursor, 'module')
+
+        with it('must have a id, model and vals properties'):
+            expect(self.r).to(have_properties('id', 'model', 'vals'))
+
+        with it('must work without noupdate'):
+            record = self.dm.records[0]
+            expect(record.noupdate).to(equal(0))
+
+        with it('must work without noupdate=1'):
+            record = self.dm.records[2]
+            expect(record.noupdate).to(equal(1))
+
+        with it('must add fields to the records'):
+            expect(self.dm.records[0].vals.keys()).to(contain('name', 'description'))
+
+        with it('must to permit create a search_params with record fields'):
+            search_params = {
+                'test.search.model': ['code']
+            }
+            cursor = Mock()
+            cursor.fetchone.return_value = [435]
+            dm = DataMigration(self.xml, cursor, 'module', search_params)
+            expect(dm.search_params).to(equal(search_params))
+
+        with it('must work with eval attribute'):
+            record = self.dm.records[1]
+            expect(record.vals['flag']).to(equal(0))
+
+        with it('must work with ref attribute'):
+            sql = self.dm.cursor.execute.call_args_list[0]
+            expected_sql = call(
+                'SELECT "a"."res_id" FROM "ir_model_data" AS "a" '
+                'WHERE (("a"."module" = %s) AND ("a"."name" = %s))',
+                ('other_module', 'xml_id')
+            )
+            expect(sql).to(equal(expected_sql))
+
+            record = self.dm.records[1]
+            expect(record.vals['relation']).to(equal(435))
+        with context('If reference does not exist'):
+            with it('must raise a KeyError exception'):
+
+                def callback():
+                    cursor = Mock()
+                    cursor.fetchone.return_value = []
+                    DataMigration(self.xml, cursor, 'module')
+
+                expect(callback).to(raise_error(
+                    KeyError,
+                    'Reference: other_module.xml_id not found'
+                ))
+
+        with description('Working with search attribute'):
+            with it('must work with search attribute'):
+                cursor = Mock()
+                cursor.fetchone.side_effect = ([435], [3])
+                dm = DataMigration(self.xml, cursor, 'module')
+                record = dm.records[1]
+                expect(record.vals['partner_id']).to(equal(3))
+
+    with description('Migrating'):
+        with it('must create the records into ir_model_data'):
+            cursor = Mock()
+            cursor.fetchone.side_effect = (
+                [5],    # other module
+                [123],  # Search partner with referece
+                [],     # No record record_id_0001
+                [1],    # Creating record_id_0001
+                [3],    # record_id_0003 found
+                [2],    # record_id_0002 found
+            )
+            dm = DataMigration(self.xml, cursor, 'module', search_params={
+                'test.search.model': ['code']
+            })
+            dm.migrate()
+            expect(cursor.execute.call_args_list).to(contain_exactly(
+                call('SELECT "a"."res_id" FROM "ir_model_data" AS "a" WHERE (("a"."module" = %s) AND ("a"."name" = %s))', ('other_module', 'xml_id')),
+                call('SELECT "a"."id" FROM "res_partner" AS "a" WHERE (("a"."ref" = %s))', ('123',)),
+                call('SELECT "a"."id" FROM "test_model" AS "a" WHERE (("a"."name" = %s) AND ("a"."description" = %s))', ('name', 'this is a description')),
+                call('INSERT INTO "test_model" ("name", "description") VALUES (%s, %s) RETURNING "id"', ('name', 'this is a description')),
+                call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0001', 'test.model', 0, 1, 'module')),
+                call('SELECT "a"."id" FROM "test_search_model" AS "a" WHERE (("a"."code" = %s))', ('code',)),
+                call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0003', 'test.search.model', 0, 3, 'module')),
+                call('SELECT "a"."id" FROM "test_model" AS "a" WHERE (("a"."name" = %s) AND ("a"."description" = %s))', ('name 2', 'this is a description 2')),
+                call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0002', 'test.model', 1, 2, 'module'))
+            ))
+
+

--- a/spec/data_migration_spec.py
+++ b/spec/data_migration_spec.py
@@ -141,13 +141,13 @@ with description('Migrating _data.xml'):
                 'test.search.model': ['code']
             })
             dm.migrate()
-            expect(cursor.execute.call_args_list).to(contain_exactly(
+            expected_sql = [
                 call('SELECT "a"."id" FROM "test_model" AS "a" WHERE (("a"."name" = %s) AND ("a"."description" = %s))', ('name', 'this is a description')),
                 call('INSERT INTO "test_model" ("name", "description") VALUES (%s, %s) RETURNING "id"', ('name', 'this is a description')),
                 call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0001', 'test.model', 0, 1, 'module')),
-                call('SELECT "a"."id" FROM "test_search_model" AS "a" WHERE (("a"."code" = %s))', ('code',)),
                 call('SELECT "a"."res_id" FROM "ir_model_data" AS "a" WHERE (("a"."module" = %s) AND ("a"."name" = %s))', ('other_module', 'xml_id')),
                 call('SELECT "a"."id" FROM "res_partner" AS "a" WHERE (("a"."ref" = %s))', ('123',)),
+                call('SELECT "a"."id" FROM "test_search_model" AS "a" WHERE (("a"."code" = %s))', ('code',)),
                 call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0003', 'test.search.model', 0, 3, 'module')),
                 call('SELECT "a"."id" FROM "test_model" AS "a" WHERE (("a"."name" = %s) AND ("a"."description" = %s))', ('name 2', 'this is a description 2')),
                 call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0002', 'test.model', 1, 2, 'module')),
@@ -155,6 +155,9 @@ with description('Migrating _data.xml'):
                 call('SELECT "a"."id" FROM "test_other_model" AS "a" WHERE (("a"."code" = %s) AND ("a"."test_model_id" = %s))', ('1', 2)),
                 call('INSERT INTO "test_other_model" ("code", "test_model_id") VALUES (%s, %s) RETURNING "id"', ('1', 2)),
                 call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0004', 'test.other.model', 0, 4, 'module'))
+            ]
+            expect(cursor.execute.call_args_list).to(contain_exactly(
+                *expected_sql
             ))
 
 

--- a/spec/data_migration_spec.py
+++ b/spec/data_migration_spec.py
@@ -7,7 +7,6 @@ from oopgrade import DataMigration
 from oopgrade.data import DataRecord
 
 
-
 with description('Migrating _data.xml'):
     with before.all:
         with open(get_fixture('migration_data.xml'), 'r') as f:
@@ -17,7 +16,9 @@ with description('Migrating _data.xml'):
         cursor = Mock()
         cursor.fetchone.return_value = [435]
         dm = DataMigration(self.xml, cursor, 'module')
-        expect(dm.records).to(have_len(3))
+        expect(dm.records).to(have_len(0))
+        dm.migrate()
+        expect(dm.records).to(have_len(4))
 
     with context('a DataRecord class'):
         with before.all:
@@ -25,6 +26,7 @@ with description('Migrating _data.xml'):
             cursor.fetchone.return_value = [435]
             self.r = DataRecord('id', 'model', 'noupdate', 'vals')
             self.dm = DataMigration(self.xml, cursor, 'module')
+            self.dm.migrate()
 
         with it('must have a id, model and vals properties'):
             expect(self.r).to(have_properties('id', 'model', 'vals'))
@@ -53,24 +55,50 @@ with description('Migrating _data.xml'):
             record = self.dm.records[1]
             expect(record.vals['flag']).to(equal(0))
 
-        with it('must work with ref attribute'):
-            sql = self.dm.cursor.execute.call_args_list[0]
-            expected_sql = call(
-                'SELECT "a"."res_id" FROM "ir_model_data" AS "a" '
-                'WHERE (("a"."module" = %s) AND ("a"."name" = %s))',
-                ('other_module', 'xml_id')
-            )
-            expect(sql).to(equal(expected_sql))
+        with context('working with the ref attribute'):
 
-            record = self.dm.records[1]
-            expect(record.vals['relation']).to(equal(435))
+            with it('must work with other module ref attribute'):
+                sql = self.dm.cursor.execute.call_args_list[2]
+                expected_sql = call(
+                    'SELECT "a"."res_id" FROM "ir_model_data" AS "a" '
+                    'WHERE (("a"."module" = %s) AND ("a"."name" = %s))',
+                    ('other_module', 'xml_id')
+                )
+                expect(sql).to(equal(expected_sql))
+
+                record = self.dm.records[1]
+                expect(record.vals['relation']).to(equal(435))
+
+            with it('must work with internal refs'):
+                sql = self.dm.cursor.execute.call_args_list[8]
+
+                expected_sql = call(
+                    'SELECT "a"."res_id" FROM "ir_model_data" AS "a" '
+                    'WHERE (("a"."module" = %s) AND ("a"."name" = %s))',
+                    ('module', 'record_id_0002')
+                )
+                expect(sql).to(equal(expected_sql))
+                record = self.dm.records[3]
+                expect(record.vals['test_model_id']).to(equal(435))
+
         with context('If reference does not exist'):
             with it('must raise a KeyError exception'):
 
                 def callback():
+                    xml = """<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="record_id_0001" model="test.search.model">
+            <field name="code">code</field>
+            <field name="relation" ref="other_module.xml_id"/>
+        </record>
+    </data>
+</openerp>
+"""
                     cursor = Mock()
                     cursor.fetchone.return_value = []
-                    DataMigration(self.xml, cursor, 'module')
+                    dm = DataMigration(xml, cursor, 'module')
+                    dm.migrate()
 
                 expect(callback).to(raise_error(
                     KeyError,
@@ -80,36 +108,53 @@ with description('Migrating _data.xml'):
         with description('Working with search attribute'):
             with it('must work with search attribute'):
                 cursor = Mock()
-                cursor.fetchone.side_effect = ([435], [3])
+                cursor.fetchone.side_effect = (
+                    [1],
+                    [6],
+                    [123],
+                    [3],
+                    [2],
+                    [2],
+                    [],
+                    [4]
+                )
                 dm = DataMigration(self.xml, cursor, 'module')
+                dm.migrate()
                 record = dm.records[1]
-                expect(record.vals['partner_id']).to(equal(3))
+                expect(record.vals['partner_id']).to(equal(123))
 
     with description('Migrating'):
         with it('must create the records into ir_model_data'):
             cursor = Mock()
             cursor.fetchone.side_effect = (
-                [5],    # other module
-                [123],  # Search partner with referece
-                [],     # No record record_id_0001
-                [1],    # Creating record_id_0001
+                [],  # No record record_id_0001
+                [1],  # Creating record_id_0001
+                [11],
+                [123],
                 [3],    # record_id_0003 found
                 [2],    # record_id_0002 found
+                [2],
+                [],
+                [4]
             )
             dm = DataMigration(self.xml, cursor, 'module', search_params={
                 'test.search.model': ['code']
             })
             dm.migrate()
             expect(cursor.execute.call_args_list).to(contain_exactly(
-                call('SELECT "a"."res_id" FROM "ir_model_data" AS "a" WHERE (("a"."module" = %s) AND ("a"."name" = %s))', ('other_module', 'xml_id')),
-                call('SELECT "a"."id" FROM "res_partner" AS "a" WHERE (("a"."ref" = %s))', ('123',)),
                 call('SELECT "a"."id" FROM "test_model" AS "a" WHERE (("a"."name" = %s) AND ("a"."description" = %s))', ('name', 'this is a description')),
                 call('INSERT INTO "test_model" ("name", "description") VALUES (%s, %s) RETURNING "id"', ('name', 'this is a description')),
                 call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0001', 'test.model', 0, 1, 'module')),
                 call('SELECT "a"."id" FROM "test_search_model" AS "a" WHERE (("a"."code" = %s))', ('code',)),
+                call('SELECT "a"."res_id" FROM "ir_model_data" AS "a" WHERE (("a"."module" = %s) AND ("a"."name" = %s))', ('other_module', 'xml_id')),
+                call('SELECT "a"."id" FROM "res_partner" AS "a" WHERE (("a"."ref" = %s))', ('123',)),
                 call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0003', 'test.search.model', 0, 3, 'module')),
                 call('SELECT "a"."id" FROM "test_model" AS "a" WHERE (("a"."name" = %s) AND ("a"."description" = %s))', ('name 2', 'this is a description 2')),
-                call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0002', 'test.model', 1, 2, 'module'))
+                call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0002', 'test.model', 1, 2, 'module')),
+                call('SELECT "a"."res_id" FROM "ir_model_data" AS "a" WHERE (("a"."module" = %s) AND ("a"."name" = %s))', ('module', 'record_id_0002')),
+                call('SELECT "a"."id" FROM "test_other_model" AS "a" WHERE (("a"."code" = %s) AND ("a"."test_model_id" = %s))', ('1', 2)),
+                call('INSERT INTO "test_other_model" ("code", "test_model_id") VALUES (%s, %s) RETURNING "id"', ('1', 2)),
+                call('INSERT INTO "ir_model_data" ("name", "model", "noupdate", "res_id", "module") VALUES (%s, %s, %s, %s, %s)', ('record_id_0004', 'test.other.model', 0, 4, 'module'))
             ))
 
 

--- a/spec/fixtures/__init__.py
+++ b/spec/fixtures/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+import os
+
+
+_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_fixture(*args):
+    return os.path.join(_ROOT, *args)

--- a/spec/fixtures/migration_data.xml
+++ b/spec/fixtures/migration_data.xml
@@ -19,4 +19,10 @@
             <field name="description">this is a description 2</field>
         </record>
     </data>
+    <data>
+        <record id="record_id_0004" model="test.other.model">
+            <field name="code">1</field>
+            <field name="test_model_id" ref="record_id_0002"/>
+        </record>
+    </data>
 </openerp>

--- a/spec/fixtures/migration_data.xml
+++ b/spec/fixtures/migration_data.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<openerp>
+    <data>
+        <record id="record_id_0001" model="test.model">
+            <field name="name">name</field>
+            <field name="description">this is a description</field>
+        </record>
+        <record id="record_id_0003" model="test.search.model">
+            <field name="code">code</field>
+            <field name="name">Name</field>
+            <field name="flag" eval="0" />
+            <field name="relation" ref="other_module.xml_id"/>
+            <field name="partner_id" model="res.partner" search="[('ref', '=', '123')]"/>
+        </record>
+    </data>
+    <data noupdate="1">
+        <record id="record_id_0002" model="test.model">
+            <field name="name">name 2</field>
+            <field name="description">this is a description 2</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Add an API to link `_data.xml` to `ir.model.data` records using migration scripts

Example:
```python
from oopgrade import DataMigration

dm = DataMigration(xml_content, cursor, 'module_name', search_params={
    'model': ['field1', 'field2']
})
dm.migrate()
```

**Note:** `search_params` is a dict with the model as a key and a list of a fields to do the match from existing resources as value. If not `search_params` is passed **all the fields in the record of `_data.xml` will be used**