### PR TITLE
Corrección de método delete records

### DIFF
--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -64,7 +64,7 @@ def delete_record(cursor, module_name, record_names):
             cursor.execute(sql_model_del, params_model_del)
 
             model_o = pool.get(model_data_vs['model'])
-            model_o.unlink(cursor, uid, model_data_vs['res_id'])
+            model_o.unlink(cursor, uid, [model_data_vs['res_id']])
         elif model_data_vs and len(model_data_vs) > 1:
             raise Exception(
                 "More than one record found for model %s" % (model_data_vs['model'])


### PR DESCRIPTION
El unlink de la mayoría de modelos debe recibir una lista de ids. Se modifica la llamada al unlink dentro del delete_records para recibir siempre una lista de ids.