### PR TITLE
Corregir bug en delete_record

### DIFF
--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -64,12 +64,12 @@ def delete_record(cursor, module_name, record_names):
             cursor.execute(sql_model_del, params_model_del)
 
             if not isinstance(model_data_vs['res_id'], (list, tuple))
-                model_data_id = [model_data_vs['res_id']]
+                model_data_ids = [model_data_vs['res_id']]
             else:
-                model_data_id = model_data_vs['res_id']
+                model_data_ids = model_data_vs['res_id']
 
             model_o = pool.get(model_data_vs['model'])
-            model_o.unlink(cursor, uid, model_data_id)
+            model_o.unlink(cursor, uid, model_data_ids)
         elif model_data_vs and len(model_data_vs) > 1:
             raise Exception(
                 "More than one record found for model %s" % (model_data_vs['model'])

--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -64,7 +64,7 @@ def delete_record(cursor, module_name, record_names):
             cursor.execute(sql_model_del, params_model_del)
 
             model_o = pool.get(model_data_vs['model'])
-            model_o.unlink(cursor, uid, model_data_vs['res_id'])
+            model_o.unlink(cursor, uid, [model_data_vs['res_id']])
         elif model_data_vs and len(model_data_vs) > 1:
             raise Exception(
                 "More than one record found for model %s" % (model_data_vs['model'])

--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -63,8 +63,13 @@ def delete_record(cursor, module_name, record_names):
             }
             cursor.execute(sql_model_del, params_model_del)
 
+            if not isinstance(model_data_vs['res_id'], (list, tuple))
+                model_data_id = [model_data_vs['res_id']]
+            else:
+                model_data_id = model_data_vs['res_id']
+
             model_o = pool.get(model_data_vs['model'])
-            model_o.unlink(cursor, uid, [model_data_vs['res_id']])
+            model_o.unlink(cursor, uid, model_data_id)
         elif model_data_vs and len(model_data_vs) > 1:
             raise Exception(
                 "More than one record found for model %s" % (model_data_vs['model'])


### PR DESCRIPTION
Quan utilitzem la funició delete_record, pot ser que el model del record tingui el unlink sobreescrit i que no comprovi si el paràmetre ids és una llista.

Això m'ha passat al voler eliminar un record del model ir.model.fields. Aquest model té sobreescrit l'unlink, però no comprova si les ids son una lllista. 