### PR TITLE
FIX column_exists query para que busque realmente oid public

### DIFF
--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -606,14 +606,13 @@ def column_exists(cr, table, column):
     :return: True if the column exists
     :rtype: bool
     """
-    cr.execute(
-        'SELECT count(attname) FROM pg_attribute WHERE attrelid = ('
-            'SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = ('
-                'SELECT oid FROM pg_namespace WHERE nspname = "public"'
-            ') AND relkind = "r"'
-        ') AND attname = %s',
-        (table, column)
+    query = (
+        "SELECT count(attname) FROM pg_attribute WHERE attrelid = ("
+        "SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = ("
+        "SELECT oid FROM pg_namespace WHERE nspname = 'public') "
+        "AND relkind = 'r') AND attname = %s"
     )
+    cr.execute(query, (table, column))
     return cr.fetchone()[0] == 1
 
 

--- a/spec/data_migration_spec.py
+++ b/spec/data_migration_spec.py
@@ -222,10 +222,10 @@ with description('Migrating _data.xml'):
             add_columns(cursor, columns, multiple=True)
             expected_sql = [
                 call(
-                    'SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = "public") AND relkind = "r") AND attname = %s', ('test_model', 'random1')
+                    "SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public') AND relkind = 'r') AND attname = %s", ('test_model', 'random1')
                 ),
                 call(
-                    'SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = "public") AND relkind = "r") AND attname = %s', ('test_model', 'random2')
+                    "SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public') AND relkind = 'r') AND attname = %s", ('test_model', 'random2')
                 ),
                 call(
                     'ALTER TABLE "test_model" ADD COLUMN "random1" character varying(16),\nADD COLUMN "random2" character varying(16)'
@@ -250,12 +250,12 @@ with description('Migrating _data.xml'):
             add_columns(cursor, columns, multiple=False)
             expected_sql = [
                 call(
-                    'SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = "public") AND relkind = "r") AND attname = %s',
+                    "SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public') AND relkind = 'r') AND attname = %s",
                     ('test_model', 'random1')),
                 call(
                     'ALTER TABLE "test_model" ADD COLUMN "random1" character varying(16)'),
                 call(
-                    'SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = "public") AND relkind = "r") AND attname = %s',
+                    "SELECT count(attname) FROM pg_attribute WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = %s AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public') AND relkind = 'r') AND attname = %s",
                     ('test_model', 'random2')),
                 call(
                     'ALTER TABLE "test_model" ADD COLUMN "random2" character varying(16)'),


### PR DESCRIPTION
La llamada de la query en el método `column_exists` era errónea por las comillas:

La query `SELECT oid FROM pg_namespace WHERE nspname= "public"` lanza error `ERROR: column "public" does not exist`

Debe ser:
`SELECT oid FROM pg_namespace WHERE nspname= 'public'`

Se arreglan los tests acorde al cambio