### PR TITLE
Cambiar modo por defecto de la función "load_data" a "update"

### DIFF
--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -93,7 +93,7 @@ def delete_record(cursor, module_name, record_names):
             )
 
 
-def load_data(cr, module_name, filename, idref=None, mode='init'):
+def load_data(cr, module_name, filename, idref=None, mode='update'):
     """
     Load an xml or csv data file from your post script. The usual case for this is the
     occurrence of newly added essential or useful data in the module that is


### PR DESCRIPTION
## Objetivos

- Para evitar problemas de sobreescritura de valores en variables u otros conflictos, se cambia el valor por defecto del parámetro `mode` de la función `load_data` de `init` a `update`, para respetar los registros que estén protegidos para rescritura.

