### PR TITLE
fix: use model instead of name

### DIFF
--- a/oopgrade/oopgrade.py
+++ b/oopgrade/oopgrade.py
@@ -722,7 +722,7 @@ def change_column_type(cursor, column_spec):
             model_data = cursor.dictfetchall()
             for model_info in model_data:
                 view_name = model_info['table_name']
-                model_exists_query = "SELECT count(id) FROM ir_model WHERE name = %s"
+                model_exists_query = "SELECT count(id) FROM ir_model WHERE model = %s"
                 cursor.execute(model_exists_query, (view_name.replace('_', '.'),))
                 res = cursor.fetchone()
                 # If exists, we store its query to create it again later


### PR DESCRIPTION
This pull request makes a small but important fix to the query used in the `change_column_type` function in `oopgrade/oopgrade.py`. The change ensures that the query checks the correct column in the `ir_model` table.

* Updated the SQL query in `change_column_type` to check the `model` column instead of the `name` column in `ir_model`, ensuring accurate existence checks for models.